### PR TITLE
Update env to match azure-search-openai-demo

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -94,7 +94,7 @@ output AZURE_RESOURCE_GROUP string = resourceGroup.name
 
 // Shared by all OpenAI deployments
 output OPENAI_HOST string = openAiHost
-output OPENAI_GPT_MODEL string = evalGptModelName
+output AZURE_OPENAI_CHATGPT_MODEL string = evalGptModelName
 // Specific to Azure OpenAI
 output AZURE_OPENAI_SERVICE string = (openAiHost == 'azure') ? openAi.outputs.name : ''
 output AZURE_OPENAI_RESOURCE_GROUP string = (openAiHost == 'azure') ? openAiResourceGroup.name : ''


### PR DESCRIPTION
I think this rename allows me to deploy [azure-search-openai-demo](https://github.com/Azure-Samples/azure-search-openai-demo), then do [azd env refresh](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/reference#azd-env-refresh) with that env name, and use all those resources (not having to recreate them) and just this source code. I don't see that val used in source code so didn't change anything else. 