### PR TITLE
Support for making a directory

### DIFF
--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -44,6 +44,9 @@ def generate_test_qa_data(
             qa.append({"question": question, "truth": answer + citation})
 
     logger.info("Writing %d questions to %s", len(qa), output_file)
+    directory = Path(output_file).parent
+    if not directory.exists():
+        directory.mkdir(parents=True)
     with open(output_file, "w") as f:
         for item in qa:
             f.write(json.dumps(item) + "\n")


### PR DESCRIPTION
## Purpose

Fixes #9

This PR changes the generate script to make sure the output directory exists. If it doesn't, it creates it.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

Try generate with a non-existent directory:

python3 -m scripts generate --output=example_input2/qa.jsonl --numquestions=2