### PR TITLE
Fix Azure OpenAI bug with API key

### DIFF
--- a/scripts/service_setup.py
+++ b/scripts/service_setup.py
@@ -57,9 +57,10 @@ def get_openai_client(oai_config: dict):
         return openai.AzureOpenAI(
             api_version=oai_config["api_version"],
             azure_endpoint=oai_config["api_base"],
-            azure_ad_token=oai_config["api_key"],
+            api_key=oai_config["api_key"] if os.environ.get("AZURE_OPENAI_KEY") else None,
+            azure_ad_token=None if os.environ.get("AZURE_OPENAI_KEY") else oai_config["api_key"],
             azure_deployment=oai_config["deployment_id"],
-        )
+    )
     else:
         return openai.OpenAI(
             api_key=oai_config["api_key"],

--- a/scripts/service_setup.py
+++ b/scripts/service_setup.py
@@ -60,7 +60,7 @@ def get_openai_client(oai_config: dict):
             api_key=oai_config["api_key"] if os.environ.get("AZURE_OPENAI_KEY") else None,
             azure_ad_token=None if os.environ.get("AZURE_OPENAI_KEY") else oai_config["api_key"],
             azure_deployment=oai_config["deployment_id"],
-    )
+        )
     else:
         return openai.OpenAI(
             api_key=oai_config["api_key"],


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Currently you can not use an Azure OpenAI endpoint with an API key as it is setting up an Azure OpenAI client using azure access token, as such when you set an AZURE_OPENAI_KEY env variable, it will provide a token error.

```python


return openai.AzureOpenAI(
            api_version=oai_config["api_version"],
            azure_endpoint=oai_config["api_base"],
            azure_ad_token=oai_config["api_key"],  <-------
            azure_deployment=oai_config["deployment_id"],
        )
```
vs
```python
return openai.AzureOpenAI(
            api_version=oai_config["api_version"],
            azure_endpoint=oai_config["api_base"],
            api_key=oai_config["api_key"], <-----
            azure_deployment=oai_config["deployment_id"],
        )
```
PR fixes this by using the api_key parameter when AZURE_OPENAI_KEY is set, otherwise will use azure_ad_token.



## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Test out evaluate script with both AZURE_OPENAI_KEY env variable set and not set
