### PR TITLE
Add optional target URL to evaluate command and CI to test evaluate

### DIFF
--- a/.github/workflows/azure-dev.yaml
+++ b/.github/workflows/azure-dev.yaml
@@ -75,3 +75,11 @@ jobs:
           AZURE_ENV_NAME: ${{ vars.AZURE_ENV_NAME }}
           AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
           AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Run evaluation
+        run: |
+          azd env get-values > .env
+          source .env
+          python -m scripts evaluate --config=example_config.json --numquestions=2 --targeturl=${{ env.TARGET_URL }}
+        env:
+          TARGET_ENDPOINT: ${{ vars.TARGET_ENDPOINT }}

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -26,6 +26,10 @@ def int_or_none(raw: str) -> int | None:
     return None if raw == "None" else int(raw)
 
 
+def str_or_none(raw: str) -> str | None:
+    return None if raw == "None" else raw
+
+
 @app.command()
 def evaluate(
     config: Path = typer.Option(
@@ -34,8 +38,13 @@ def evaluate(
     numquestions: int | None = typer.Option(
         help="Number of questions to evaluate (defaults to all if not specified).", default=None, parser=int_or_none
     ),
+    targeturl: str | None = typer.Option(
+        help="URL of the target service to evaluate against (defaults to the one in the config).",
+        default=None,
+        parser=str_or_none,
+    ),
 ):
-    run_evaluate_from_config(Path.cwd(), config, numquestions)
+    run_evaluate_from_config(Path.cwd(), config, numquestions, targeturl)
 
 
 @app.command()

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -190,7 +190,7 @@ def process_config(obj: dict):
                     obj[key] = f.read()
 
 
-def run_evaluate_from_config(working_dir, config_path, num_questions):
+def run_evaluate_from_config(working_dir, config_path, num_questions, target_url):
     config_path = working_dir / Path(config_path)
     logger.info("Running evaluation from config %s", config_path)
     with open(config_path, encoding="utf-8") as f:
@@ -203,7 +203,7 @@ def run_evaluate_from_config(working_dir, config_path, num_questions):
         openai_config=service_setup.get_openai_config(),
         testdata_path=working_dir / config["testdata_path"],
         results_dir=results_dir,
-        target_url=config["target_url"],
+        target_url=target_url or config["target_url"],
         target_parameters=config.get("target_parameters", {}),
         num_questions=num_questions,
         requested_metrics=config.get(


### PR DESCRIPTION
## Purpose

This PR adds an optional target URL to the evaluate command and uses that in a CI which tests the evaluate flow.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Run evaluate with and without targeturl
*  Wait for CI to succeed