### PR TITLE
Update to new Protocol response format, use JMESPath expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,11 +214,10 @@ These metrics are calculated with some local code based on the results of the ch
 
 ### Sending additional parameters to the app
 
-This repo assumes that your chat app is following the [Chat App Protocol](https://github.com/Azure-Samples/ai-chat-app-protocol), which means that all POST requests look like this:
+This repo assumes that your chat app is following the [AI Chat Protocol](https://github.com/microsoft/ai-chat-protocol/tree/main/spec#readme), which means that all POST requests look like this:
 
 ```json
 {"messages": [{"content": "<Actual user question goes here>", "role": "user"}],
- "stream": False,
  "context": {...},
 }
 ```
@@ -237,6 +236,18 @@ Any additional app parameters would be specified in the `context` of that JSON, 
 The `overrides` key is the same as the `overrides` key in the `context` of the POST request.
 As a convenience, you can use the `<READFILE>` prefix to read in a file and use its contents as the value for the parameter.
 That way, you can store potential (long) prompts separately from the config JSON file.
+
+### Specifying the location of answer and context in response
+
+The evaluator needs to know where to find the answer and context in the response from the chat app.
+If your app returns responses following the recommendations of the [AI Chat Protocol](https://github.com/microsoft/ai-chat-protocol/tree/main/spec#readme), then the answer will be "message": "content" and the context will be a list of strings in "context": "data_points": "text".
+
+If your app returns responses in a different format, you can specify the [JMESPath expressions](https://jmespath.org/) to extract the answer and context from the response. For example:
+
+```json
+    "target_response_answer_jmespath": "message.content",
+    "target_response_context_jmespath": "context.data_points.text"
+```
 
 ## Viewing the results
 
@@ -325,7 +336,9 @@ Here's an example configuration JSON that requests that metric, referencing the 
     "requested_metrics": ["dontknowness", "answer_length", "latency", "has_citation"],
     "target_url": "http://localhost:50505/chat",
     "target_parameters": {
-    }
+    },
+    "target_response_answer_jmespath": "message.content",
+    "target_response_context_jmespath": "context.data_points.text"
 }
 ```
 

--- a/example_config.json
+++ b/example_config.json
@@ -5,8 +5,23 @@
     "target_url": "http://localhost:50505/chat",
     "target_parameters": {
         "overrides": {
-            "semantic_ranker": false,
-            "prompt_template": "<READFILE>example_input/prompt_refined.txt"
+            "top": 3,
+            "temperature": 0.3,
+            "minimum_reranker_score": 0,
+            "minimum_search_score": 0,
+            "retrieval_mode": "hybrid",
+            "semantic_ranker": true,
+            "semantic_captions": false,
+            "suggest_followup_questions": false,
+            "use_oid_security_filter": false,
+            "use_groups_security_filter": false,
+            "vector_fields": [
+                "embedding"
+            ],
+            "use_gpt4v": false,
+            "gpt4v_input": "textAndImages"
         }
-    }
+    },
+    "target_response_answer_jmespath": "choices[0].message.content",
+    "target_response_context_jmespath": "choices[0].context.data_points.text"
 }

--- a/example_config.json
+++ b/example_config.json
@@ -22,6 +22,6 @@
             "gpt4v_input": "textAndImages"
         }
     },
-    "target_response_answer_jmespath": "choices[0].message.content",
-    "target_response_context_jmespath": "choices[0].context.data_points.text"
+    "target_response_answer_jmespath": "message.content",
+    "target_response_context_jmespath": "context.data_points.text"
 }

--- a/scripts/evaluate_metrics/code_metrics.py
+++ b/scripts/evaluate_metrics/code_metrics.py
@@ -1,6 +1,9 @@
+import logging
 import re
 
 from .base_metric import BaseMetric
+
+logger = logging.getLogger("scripts")
 
 
 class AnswerLengthMetric(BaseMetric):
@@ -10,12 +13,17 @@ class AnswerLengthMetric(BaseMetric):
     @classmethod
     def evaluator_fn(cls, **kwargs):
         def answer_length(*, answer, **kwargs):
-            return {AnswerLengthMetric.METRIC_NAME: len(answer)}
+            if answer is None:
+                logger.warning("Received answer of None, can't compute answer_length metric. Setting to -1.")
+                return {cls.METRIC_NAME: -1}
+            return {cls.METRIC_NAME: len(answer)}
 
         return answer_length
 
     @classmethod
     def get_aggregate_stats(cls, df):
+        # remove -1 values from the mean calculation
+        df = df[df[cls.METRIC_NAME] != -1]
         return {
             "mean": round(df[cls.METRIC_NAME].mean(), 2),
             "max": int(df[cls.METRIC_NAME].max()),
@@ -30,12 +38,16 @@ class HasCitationMetric(BaseMetric):
     @classmethod
     def evaluator_fn(cls, **kwargs):
         def has_citation(*, answer, **kwargs):
-            return {"has_citation": bool(re.search(r"\[[^\]]+\]", answer))}
+            if answer is None:
+                logger.warning("Received answer of None, can't compute has_citation metric. Setting to -1.")
+                return {cls.METRIC_NAME: -1}
+            return {cls.METRIC_NAME: bool(re.search(r"\[[^\]]+\]", answer))}
 
         return has_citation
 
     @classmethod
     def get_aggregate_stats(cls, df):
+        df = df[df[cls.METRIC_NAME] != -1]
         return {
             "total": int(df[cls.METRIC_NAME].sum()),
             "rate": round(df[cls.METRIC_NAME].mean(), 2),
@@ -49,16 +61,20 @@ class CitationMatchMetric(BaseMetric):
     @classmethod
     def evaluator_fn(cls, **kwargs):
         def citation_match(*, answer, ground_truth, **kwargs):
+            if answer is None:
+                logger.warning("Received answer of None, can't compute citation_match metric. Setting to -1.")
+                return {cls.METRIC_NAME: -1}
             # Return true if all citations in the truth are present in the answer
             truth_citations = set(re.findall(r"\[([^\]]+)\.\w{3,4}\]", ground_truth))
             answer_citations = set(re.findall(r"\[([^\]]+)\.\w{3,4}\]", answer))
             citation_match = truth_citations.issubset(answer_citations)
-            return {"citation_match": citation_match}
+            return {cls.METRIC_NAME: citation_match}
 
         return citation_match
 
     @classmethod
     def get_aggregate_stats(cls, df):
+        df = df[df[cls.METRIC_NAME] != -1]
         return {
             "total": int(df[cls.METRIC_NAME].sum()),
             "rate": round(df[cls.METRIC_NAME].mean(), 2),

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -7,3 +7,4 @@ typer
 openai>=1.0.0
 pandas
 rich
+jmespath

--- a/scripts/tests/test_evaluate.py
+++ b/scripts/tests/test_evaluate.py
@@ -8,12 +8,8 @@ from scripts.evaluate import send_question_to_target
 def test_send_question_to_target_valid():
     # Test case 1: Valid response
     response = {
-        "choices": [
-            {
-                "message": {"content": "This is the answer"},
-                "context": {"data_points": {"text": ["Context 1", "Context 2"]}},
-            }
-        ]
+        "message": {"content": "This is the answer"},
+        "context": {"data_points": {"text": ["Context 1", "Context 2"]}},
     }
     requests.post = lambda url, headers, json: MockResponse(response)
     result = send_question_to_target("Question 1", "http://example.com")
@@ -23,26 +19,28 @@ def test_send_question_to_target_valid():
 
 
 def test_send_question_to_target_missing_error_store():
-    # Test case 2: Missing 'choices' key in response
     response = {}
     requests.post = lambda url, headers, json: MockResponse(response)
     result = send_question_to_target("Question", "http://example.com")
     assert result["answer"] == (
         "Response does not adhere to the expected schema. "
+        "The answer should be accessible via the JMESPath expression 'message.content' "
+        "and the context should be accessible via the JMESPath expression 'context.data_points.text'. "
         "Either adjust the app response or adjust send_question_to_target() "
         "in evaluate.py to match the actual schema.\n"
         "Response: {}"
     )
     assert result["context"] == (
         "Response does not adhere to the expected schema. "
+        "The answer should be accessible via the JMESPath expression 'message.content' "
+        "and the context should be accessible via the JMESPath expression 'context.data_points.text'. "
         "Either adjust the app response or adjust send_question_to_target() "
         "in evaluate.py to match the actual schema.\n"
         "Response: {}"
     )
 
 
-def test_send_question_to_target_missing_choices():
-    # Test case 2: Missing 'choices' key in response
+def test_send_question_to_target_missing_all():
     response = {}
     requests.post = lambda url, headers, json: MockResponse(response)
     try:
@@ -50,6 +48,8 @@ def test_send_question_to_target_missing_choices():
     except Exception as e:
         assert str(e) == (
             "Response does not adhere to the expected schema. "
+            "The answer should be accessible via the JMESPath expression 'message.content' "
+            "and the context should be accessible via the JMESPath expression 'context.data_points.text'. "
             "Either adjust the app response or adjust send_question_to_target() "
             "in evaluate.py to match the actual schema.\n"
             "Response: {}"
@@ -57,32 +57,35 @@ def test_send_question_to_target_missing_choices():
 
 
 def test_send_question_to_target_missing_content():
-    # Test case 4: Missing 'content' key in response['choices'][0]['message']
-    response = {"choices": [{"message": {}, "context": {"data_points": {"text": ["Context 1", "Context 2"]}}}]}
+    response = {"message": {}, "context": {"data_points": {"text": ["Context 1", "Context 2"]}}}
     requests.post = lambda url, headers, json: MockResponse(response)
     try:
         send_question_to_target("Question", "Answer", "http://example.com", raise_error=True)
     except Exception as e:
         assert str(e) == (
             "Response does not adhere to the expected schema. "
+            "The answer should be accessible via the JMESPath expression 'message.content' "
+            "and the context should be accessible via the JMESPath expression 'context.data_points.text'. "
             "Either adjust the app response or adjust send_question_to_target() "
             "in evaluate.py to match the actual schema.\n"
-            "Response: {'choices': [{'message': {}, 'context': {'data_points': {'text': ['Context 1', 'Context 2']}}}]}"
+            "Response: {'message': {}, 'context': {'data_points': {'text': ['Context 1', 'Context 2']}}}"
         )
 
 
 def test_send_question_to_target_missing_context():
-    # Test case 5: Missing 'context' key in response['choices'][0]
-    response = {"choices": [{"message": {"content": "This is the answer"}}]}
+    # Test case 5: Missing 'context' key in response
+    response = {"message": {"content": "This is the answer"}}
     requests.post = lambda url, headers, json: MockResponse(response)
     try:
         send_question_to_target("Question", "Answer", "http://example.com", raise_error=True)
     except Exception as e:
         assert str(e) == (
             "Response does not adhere to the expected schema. "
+            "The answer should be accessible via the JMESPath expression 'message.content' "
+            "and the context should be accessible via the JMESPath expression 'context.data_points.text'. "
             "Either adjust the app response or adjust send_question_to_target() "
             "in evaluate.py to match the actual schema.\n"
-            "Response: {'choices': [{'message': {'content': 'This is the answer'}}]}"
+            "Response: {'message': {'content': 'This is the answer'}}"
         )
 
 

--- a/scripts/tests/test_evaluate_metrics.py
+++ b/scripts/tests/test_evaluate_metrics.py
@@ -12,6 +12,14 @@ def test_answer_length():
     assert metric.get_aggregate_stats(df) == {"mean": 11.67, "max": 20, "min": 5}
 
 
+def test_answer_length_new():
+    metric = code_metrics.AnswerLengthMetric()
+    metric_function = metric.evaluator_fn()
+    assert metric_function(answer=None) == {"answer_length": -1}
+    df = pd.DataFrame([{"answer_length": 20}, {"answer_length": 10}, {"answer_length": 5}, {"answer_length": -1}])
+    assert metric.get_aggregate_stats(df) == {"mean": 11.67, "max": 20, "min": 5}
+
+
 def test_has_citation():
     metric = code_metrics.HasCitationMetric()
     metric_function = metric.evaluator_fn()
@@ -21,6 +29,14 @@ def test_has_citation():
 
     df = pd.DataFrame([{"has_citation": True}, {"has_citation": False}, {"has_citation": True}])
     assert metric.get_aggregate_stats(df) == {"total": 2, "rate": 0.67}
+
+
+def test_has_citation_none():
+    metric = code_metrics.HasCitationMetric()
+    metric_function = metric.evaluator_fn()
+    assert metric_function(answer=None) == {"has_citation": -1}
+    df = pd.DataFrame([{"has_citation": True}, {"has_citation": False}, {"has_citation": -1}])
+    assert metric.get_aggregate_stats(df) == {"total": 1, "rate": 0.5}
 
 
 def test_citation_match():
@@ -46,6 +62,14 @@ def test_citation_match_filenames_only():
     metric = code_metrics.CitationMatchMetric()
     metric_function = metric.evaluator_fn()
     assert metric_function(ground_truth=truth, answer=answer) == {"citation_match": True}
+
+
+def test_citation_match_none():
+    metric = code_metrics.CitationMatchMetric()
+    metric_function = metric.evaluator_fn()
+    assert metric_function(ground_truth="Answer", answer=None) == {"citation_match": -1}
+    df = pd.DataFrame([{"citation_match": True}, {"citation_match": False}, {"citation_match": -1}])
+    assert metric.get_aggregate_stats(df) == {"total": 1, "rate": 0.5}
 
 
 def test_latency():


### PR DESCRIPTION
## Purpose

This PR updates the evaluator to assume that the server uses the new AI Protocol, which has a slightly different JSON response format. Corresponding changes in azure-search-openai-demo are here: https://github.com/Azure-Samples/azure-search-openai-demo/pull/1682

At the same time, this PR adds JMESPath expression support so that developers can easily customize the location of the answer and context in the returned JSON, so that you can use it with older protocol versions or your own custom format.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[X] Yes - Developers should add the JMESPath parameters to match their response format if using this with a Chat App using older protocol.
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Run tests
* Run against old server using choices[0].message.content