### PR TITLE
Don't misuse the model configuration to store extra keys

### DIFF
--- a/src/evaltools/review/diff_markdown.py
+++ b/src/evaltools/review/diff_markdown.py
@@ -1,6 +1,13 @@
 from pathlib import Path
+from typing import Any
 
 from .utils import diff_directories
+
+
+def _round_metric(value: Any) -> Any:
+    if isinstance(value, float):
+        return round(value, 1)
+    return value
 
 
 def main(directories: list[Path], changed: str | None = None):
@@ -29,14 +36,14 @@ def main(directories: list[Path], changed: str | None = None):
             if isinstance(value, int | float):
                 metrics[column] = []
         for metric_name in metrics.keys():
+            first_value = _round_metric(data_dicts[0][question].get(metric_name))
             for ind, data_dict in enumerate(data_dicts):
-                value = data_dict[question].get(metric_name)
-                value_str = str(round(value, 1) if isinstance(value, float) else value)
+                value = _round_metric(data_dict[question].get(metric_name))
                 # Insert arrow emoji based on the difference between metric value and the first data_dict
                 value_emoji = ""
-                if value is not None and ind > 0 and value != data_dicts[0][question][metric_name]:
+                if value is not None and ind > 0 and value != first_value:
                     value_emoji = "⬆️" if value > data_dicts[0][question][metric_name] else "⬇️"
-                metrics[metric_name].append(f"{value_str} {value_emoji}")
+                metrics[metric_name].append(f"{value} {value_emoji}")
         # make a row for each metric
         for metric_name, metric_values in metrics.items():
             markdown_str += (

--- a/src/evaltools/service_setup.py
+++ b/src/evaltools/service_setup.py
@@ -38,7 +38,6 @@ def get_openai_config() -> dict:
             }
             # azure-ai-evaluate will call DefaultAzureCredential behind the scenes,
             # so we must be logged in to Azure CLI with the correct tenant
-        openai_config["model"] = os.environ["OPENAI_GPT_MODEL"]
     else:
         logger.info("Using OpenAI Service with API Key from OPENAICOM_KEY")
         openai_config: OpenAIModelConfiguration = {
@@ -97,14 +96,13 @@ def get_search_client():
     )
 
 
-def get_openai_client(oai_config: Union[AzureOpenAIModelConfiguration, OpenAIModelConfiguration]):
+def get_openai_client(
+    oai_config: Union[AzureOpenAIModelConfiguration, OpenAIModelConfiguration], azure_credential=None
+):
     if "azure_deployment" in oai_config:
         azure_token_provider = None
-        azure_credential = None
-        if "credential" in oai_config:
-            logger.info("Using Azure OpenAI Service with provided credential")
-            azure_credential = oai_config["credential"]
-        elif not os.environ.get("AZURE_OPENAI_KEY"):
+
+        if azure_credential is None and not os.environ.get("AZURE_OPENAI_KEY"):
             logger.info("Using Azure OpenAI Service with Azure Developer CLI Credential")
             azure_credential = get_azd_credential(os.environ.get("AZURE_OPENAI_TENANT_ID"))
         if azure_credential is not None:


### PR DESCRIPTION
## Purpose

The latest azure-ai-evaluation SDK doesn't like that. This moves them into separate parameters.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Tested both here and in azure-search-openai-demo